### PR TITLE
Fix unresolved references in kdoc comments

### DIFF
--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/database/column/ColumnType.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/database/column/ColumnType.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.full.safeCast
 
 /**
  * Specifies the type of a Cottontail DB [Column]. This construct allows for some degree of type safety in the eye de-/serialization.
- * The column types are stored as strings and mapped to the respective class using [ColumnType.typeForName].
+ * The column types are stored as strings and mapped to the respective class using [ColumnType.forName].
  *
  * @see Column
  *

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/database/entity/EntityInternal.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/database/entity/EntityInternal.kt
@@ -99,10 +99,10 @@ internal object EntityHeaderSerializer : Serializer<EntityHeader> {
 }
 
 /**
- * An entry pointing to an [Index]
+ * An entry pointing to an [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]
  *
  * @see Entity
- * @see Index
+ * @see ch.unibas.dmi.dbis.cottontail.database.index.Index
  *
  * @author Ralph Gasser
  * @version 1.0

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/database/queries/Predicate.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/database/queries/Predicate.kt
@@ -10,7 +10,8 @@ import ch.unibas.dmi.dbis.cottontail.model.values.Value
 import ch.unibas.dmi.dbis.cottontail.model.values.VectorValue
 
 /**
- * A general purpose [Predicate] that describes a Cottontail DB query. It can either operate on [Recordset]s or data read from an [Entity].
+ * A general purpose [Predicate] that describes a Cottontail DB query. It can either operate on [Recordset][ch.unibas.dmi.dbis.cottontail.model.recordset.Recordset]s
+ * or data read from an [Entity].
  *
  * @author Ralph Gasser
  * @version 1.0

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/database/schema/Schema.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/database/schema/Schema.kt
@@ -203,7 +203,8 @@ class Schema(n: Name, override val path: Path, override val parent: Catalogue) :
     /**
      * Closes this [Schema] and all the [Entity] objects that are contained within.
      *
-     * Since locks to [DBO] or [Transaction] objects may be held by other threads, it can take a
+     * Since locks to [DBO] or [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction]
+     * objects may be held by other threads, it can take a
      * while for this method to complete.
      */
     override fun close() = this.lock.write {

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/ExecutionPlan.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/ExecutionPlan.kt
@@ -23,7 +23,7 @@ import kotlin.collections.HashMap
 /**
  * A configurable execution plan for Cottontail DB queries. This class can be used to specify exactly,
  * how a query should be executed. The execution plan can be configured, by adding different,
- * interdependent [ExecutionTask]s to the [ExcutionPlan]
+ * interdependent [ExecutionTask]s to the [ExecutionPlan]
  *
  * @see ExecutionTask
  *

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/Exceptions.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/Exceptions.kt
@@ -6,7 +6,7 @@ import ch.unibas.dmi.dbis.cottontail.execution.tasks.basics.ExecutionTask
 /**
  * This exceptions is thrown whenever a single [ExecutionPlan] fails.
  *
- * @param task The [ExecutionPlan] that failed.
+ * @param plan The [ExecutionPlan] that failed.
  * @param message An error message describing the circumstances.
  */
 class ExecutionPlanException(plan: ExecutionPlan, message: String) : Throwable("Execution failed for execution plan ${plan.id}: $message.")
@@ -15,7 +15,7 @@ class ExecutionPlanException(plan: ExecutionPlan, message: String) : Throwable("
  * This exceptions is thrown whenever the setup of an [ExecutionPlan] fails. Errors of this kind are is usually caused
  * by mal-specification.
  *
- * @param task The [ExecutionPlan] that failed.
+ * @param plan The [ExecutionPlan] that failed.
  * @param message An error message describing the circumstances.
  */
 class ExecutionPlanSetupException(plan: ExecutionPlan, message: String) : Throwable("Setup failed for execution plan ${plan.id}: $message.")

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/basics/ExecutionTask.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/basics/ExecutionTask.kt
@@ -8,9 +8,9 @@ import java.util.*
 
 /**
  * A single task usually executed as part of a query. Such as task generated a [Recordset] by  fetching or
- * transforming data. [ExecutionTask]s are usually part of an [ExecutionPlan].
+ * transforming data. [ExecutionTask]s are usually part of an [ExecutionPlan][ch.unibas.dmi.dbis.cottontail.execution.ExecutionPlan].
  *
- * @see ExecutionPlan
+ * @see ch.unibas.dmi.dbis.cottontail.execution.ExecutionPlan
  * @see Recordset
  *
  * @author Ralph Gasser

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/entity/boolean/EntityIndexedFilterTask.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/entity/boolean/EntityIndexedFilterTask.kt
@@ -8,7 +8,9 @@ import ch.unibas.dmi.dbis.cottontail.execution.tasks.basics.ExecutionTask
 import ch.unibas.dmi.dbis.cottontail.model.recordset.Recordset
 
 /**
- * A [Task] that executes data access through an index on a defined [Entity] using a [BooleanPredicate]. Only returns [Record]s that match the provided [BooleanPredicate].
+ * A [Task][com.github.dexecutor.core.task.Task] that executes data access through an index on a defined
+ * [Entity] using a [BooleanPredicate]. Only returns [Record][ch.unibas.dmi.dbis.cottontail.model.basics.Record]s
+ * that match the provided [BooleanPredicate].
  *
  * @author Ralph Gasser
  * @version 1.0

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/entity/boolean/EntityLinearScanFilterTask.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/entity/boolean/EntityLinearScanFilterTask.kt
@@ -10,7 +10,8 @@ import ch.unibas.dmi.dbis.cottontail.model.recordset.Recordset
 import com.github.dexecutor.core.task.Task
 
 /**
- * A [Task] that executes a full table boolean on a defined [Entity] using a [BooleanPredicate]. Only returns [Record]s that match the provided [BooleanPredicate].
+ * A [Task] that executes a full table boolean on a defined [Entity] using a [BooleanPredicate]
+ * Only returns [Record][ch.unibas.dmi.dbis.cottontail.model.basics.Record]s that match the provided [BooleanPredicate].
  *
  * @author Ralph Gasser
  * @version 1.0

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/entity/fetch/EntityFetchColumnsTask.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/entity/fetch/EntityFetchColumnsTask.kt
@@ -11,7 +11,8 @@ import com.github.dexecutor.core.task.Task
 import com.github.dexecutor.core.task.TaskExecutionException
 
 /**
- * A [Task] used during query execution. It takes a [Recordset] as input, fetches the desired [Column]s from the specified [Entity] and appends them to the original [Recordset].
+ * A [Task] used during query execution. It takes a [Recordset] as input, fetches the desired [Column][ch.unibas.dmi.dbis.cottontail.database.column.Column]s
+ * from the specified [Entity] and appends them to the original [Recordset].
  *
  * @author Ralph Gasser
  * @version 1.0

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/entity/knn/LinearEntityScanKnnTask.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/entity/knn/LinearEntityScanKnnTask.kt
@@ -15,7 +15,8 @@ import ch.unibas.dmi.dbis.cottontail.model.values.VectorValue
 import com.github.dexecutor.core.task.Task
 
 /**
- * A [Task] that executes a sequential boolean kNN on a float [Column] of the specified [Entity].
+ * A [Task] that executes a sequential boolean kNN on a float [Column][ch.unibas.dmi.dbis.cottontail.database.column.Column]
+ * of the specified [Entity].
  *
  * @author Ralph Gasser
  * @version 1.1

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/entity/knn/ParallelEntityScanKnnTask.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/entity/knn/ParallelEntityScanKnnTask.kt
@@ -21,7 +21,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 /**
- * A [Task] that executes a parallel boolean kNN on a [Column] of the specified [Entity]. Parallelism is achieved through the use of co-routines.
+ * A [Task] that executes a parallel boolean kNN on a [Column][ch.unibas.dmi.dbis.cottontail.database.column.Column]
+ * of the specified [Entity]. Parallelism is achieved through the use of co-routines.
  *
  * @author Ralph Gasser
  * @version 1.1

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/recordset/merge/RecordsetIntersectTask.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/recordset/merge/RecordsetIntersectTask.kt
@@ -8,7 +8,7 @@ import java.lang.IllegalArgumentException
 
 /**
  * A [Task] used during query execution. It takes two [Recordset]s as input and creates a new [Recordset] containing the INTERSECTION of the two inputs. The INTERSECTION is
- * based on the tuple ID of the individual [Record]s.
+ * based on the tuple ID of the individual [Record][ch.unibas.dmi.dbis.cottontail.model.basics.Record]s.
  *
  * @author Ralph Gasser
  * @version 1.0

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/recordset/projection/RecordsetSelectProjectionTask.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/execution/tasks/recordset/projection/RecordsetSelectProjectionTask.kt
@@ -15,8 +15,8 @@ import com.github.dexecutor.core.task.Task
 import com.github.dexecutor.core.task.TaskExecutionException
 
 /**
- * A [Task] used during query execution. It takes a single [Recordset] as input and fetches the specified [Column] values from the
- * specified [Entity] in order to addRow these values to the resulting [Recordset].
+ * A [Task] used during query execution. It takes a single [Recordset] as input and fetches the specified [Column][ch.unibas.dmi.dbis.cottontail.database.column.Column]
+ * values from the specified [Entity] in order to addRow these values to the resulting [Recordset].
  *
  * A [Recordset] that undergoes this task will grow in terms of columns it contains. However, it should not affect the number of rows.
  *

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/basics/ColumnDef.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/basics/ColumnDef.kt
@@ -39,7 +39,7 @@ class ColumnDef<T: Any> (name: Name, val type: ColumnType<T>, val size: Int = -1
      * Validates a value with regard to this [ColumnDef] and throws an Exception, if validation fails.
      *
      * @param value The value that should be validated.
-     * @throws [DatabaseException.ValidationException] If validation fails.
+     * @throws ValidationException If validation fails.
      */
     fun validateOrThrow(value: Value<*>?) {
         if (value != null) {

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/basics/Record.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/basics/Record.kt
@@ -6,13 +6,14 @@ import java.lang.IllegalArgumentException
 /**
  * A [Record] as returned and processed by Cottontail DB. A [Record] corresponds to a single row and
  * it can hold multiple values, each belonging to a different column (defined by [ColumnDef]s). A [ColumnDef]
- * must not necessarily correspond to a physical database [Column].
+ * must not necessarily correspond to a physical database [Column][ch.unibas.dmi.dbis.cottontail.database.column.Column].
  *
- * Column-wise access to records through the [Entity] class returns [Record]s. Furthermore, the interface is
- * used in conjunction with the [Recordset] class.
+ * Column-wise access to records through the [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity]
+ * class returns [Record]s. Furthermore, the interface is
+ * used in conjunction with the [Recordset][ch.unibas.dmi.dbis.cottontail.model.recordset.Recordset] class.
  *
- * @see Recordset
- * @see Entity
+ * @see ch.unibas.dmi.dbis.cottontail.model.recordset.Recordset
+ * @see ch.unibas.dmi.dbis.cottontail.database.entity.Entity
  *
  * @author Ralph Gasser
  * @version 1.0
@@ -22,7 +23,7 @@ interface Record {
     /** The Tuple ID of the [Record]. Usually corresponds to a tupleId in the underlying database. */
     val tupleId: Long
 
-    /** Array of [ColumnDef]s that describes the [Columns] of this [Record]. */
+    /** Array of [ColumnDef]s that describes the [Columns][ch.unibas.dmi.dbis.cottontail.database.column.Column] of this [Record]. */
     val columns: Array<out ColumnDef<*>>
 
     /** Array of column values (one entry per column). */

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/exceptions/DatabaseException.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/exceptions/DatabaseException.kt
@@ -6,66 +6,75 @@ import org.mapdb.DBException
 
 open class DatabaseException(message: String) : Throwable(message) {
     /**
-     * Thrown when trying to create a [Schema] that does already exist.
+     * Thrown when trying to create a [Schema][ch.unibas.dmi.dbis.cottontail.database.schema.Schema]
+     * that does already exist.
      *
-     * @param entity [Name] of the [Schema].
+     * @param schema [Name] of the [Schema][ch.unibas.dmi.dbis.cottontail.database.schema.Schema].
      */
     class SchemaAlreadyExistsException(schema: Name): DatabaseException("Schema '$schema' does already exist!")
 
     /**
-     * Thrown when trying to access a [Schema] that does not exist.
+     * Thrown when trying to access a [Schema][ch.unibas.dmi.dbis.cottontail.database.schema.Schema]
+     * that does not exist.
      *
-     * @param entity [Name] of the [Schema].
+     * @param schema [Name] of the [Schema][ch.unibas.dmi.dbis.cottontail.database.schema.Schema].
      */
     class SchemaDoesNotExistException(schema: Name): DatabaseException("Schema '$schema' does not exist!")
 
     /**
-     * Thrown when trying to create an [Entity] that does already exist.
+     * Thrown when trying to create an [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity]
+     * that does already exist.
      *
-     * @param entity [Name] of the [Entity].
+     * @param entity [Name] of the [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity].
      */
     class EntityAlreadyExistsException(entity: Name): DatabaseException("Entity '$entity' does already exist!")
 
     /**
-     * Thrown when trying to access an [Entity] that does not exist.
+     * Thrown when trying to access an [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity]
+     * that does not exist.
      *
-     * @param entity [Name] of the [Entity].
+     * @param entity [Name] of the [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity].
      */
     class EntityDoesNotExistException(entity: Name): DatabaseException("Entity '$entity' does not exist!")
 
     /**
-     * Thrown whenever trying to create an [Index] that does already exist.
+     * Thrown whenever trying to create an [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]
+     * that does already exist.
      *
-     * @param index The [Name] of the [Index]
+     * @param index The [Name] of the [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]
      */
     class IndexAlreadyExistsException(val index: String): DatabaseException("Index '$index' does already exist!")
 
     /**
-     * Thrown whenever trying to access an [Index] that does not exist.
+     * Thrown whenever trying to access an [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]
+     * that does not exist.
      *
-     * @param index The [Name] of the [Index]
+     * @param index The [Name] of the [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]
      */
     class IndexDoesNotExistException(val index: String): DatabaseException("Index '$index' does not exist!")
 
     /**
-     * Thrown upon creation of an [Entity] if the definition contains duplicate column names.
+     * Thrown upon creation of an [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity]
+     * if the definition contains duplicate column names.
      *
-     * @param fqn [Name] of the affected [Entity]
-     * @param columns [Name] of the [Column]s in the definition.
+     * @param entity [Name] of the affected [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity]
+     * @param columns [Name] of the [Column][ch.unibas.dmi.dbis.cottontail.database.column.Column]s in the definition.
      */
     class DuplicateColumnException(entity: Name, columns: Collection<Name>) : DatabaseException("Entity '$entity' could not be created because it contains duplicate column names (c=[${columns.joinToString(",")}])!")
 
     /**
-     * Thrown whenever trying to access a [Column] that does not exist.
+     * Thrown whenever trying to access a [Column][ch.unibas.dmi.dbis.cottontail.database.column.Column]
+     * that does not exist.
      *
-     * @param column The [Name] of the [Column].
+     * @param column The [Name] of the [Column][ch.unibas.dmi.dbis.cottontail.database.column.Column].
      */
     class ColumnDoesNotExistException(val column: Name): DatabaseException("Column $column does not exist.")
 
     /**
-     * Thrown by [Index]es if they are given a [Predicate] they cannot executed.
+     * Thrown by [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]es if they are given a
+     * [Predicate][ch.unibas.dmi.dbis.cottontail.database.queries.Predicate] they cannot executed.
      *
-     * @param index [Name] of the affected [Index]
+     * @param index [Name] of the affected [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]
      */
     class PredicateNotSupportedBxIndexException(index: Name): DatabaseException("Index '$index' cannot be used to execute the given predicate.")
 

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/exceptions/QueryException.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/exceptions/QueryException.kt
@@ -29,8 +29,10 @@ open class QueryException(message: String) : DatabaseException(message) {
     class QuerySyntaxException(message: String): DatabaseException(message)
 
     /**
-     * This kind of exception is thrown whenever a query fails to bind to a specific [DBO]. This is usually
-     *  the case, if [Schema], [Entity] or [Column] names are not spelt correctly.
+     * This kind of exception is thrown whenever a query fails to bind to a specific [DBO][ch.unibas.dmi.dbis.cottontail.database.general.DBO].
+     * This is usually the case, if [Schema][ch.unibas.dmi.dbis.cottontail.database.schema.Schema],
+     * [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity] or [Column][ch.unibas.dmi.dbis.cottontail.database.column.Column]
+     * names are not spelt correctly.
      *
      * @param message Message describing the issue with the query.
      */
@@ -44,15 +46,17 @@ open class QueryException(message: String) : DatabaseException(message) {
     class UnsupportedCastException(message: String): DatabaseException(message)
 
     /**
-     * This kind of exception is thrown whenever a [Predicate] is applied that is not supported by the data structure it is supplied to.
+     * This kind of exception is thrown whenever a [Predicate][ch.unibas.dmi.dbis.cottontail.database.queries.Predicate]
+     * is applied that is not supported by the data structure it is supplied to.
      *
      * @param message Message describing the issue with the query.
      */
     class UnsupportedPredicateException(message: String): DatabaseException(message)
 
     /**
-     * This kind of exception is thrown whenever a [Predicate] is routed through an [Index] that does not
-     * support that kind of [Predicate].
+     * This kind of exception is thrown whenever a [Predicate][ch.unibas.dmi.dbis.cottontail.database.queries.Predicate]
+     * is routed through an [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]
+     * that does not support that kind of [Predicate][ch.unibas.dmi.dbis.cottontail.database.queries.Predicate].
      *
      * @param index FQN of the index.
      * @param message Error message

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/exceptions/TransactionException.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/exceptions/TransactionException.kt
@@ -6,50 +6,56 @@ import java.util.*
 
 
 /**
- * These exceptions are thrown whenever a [Transaction] or an action making up a [Transaction] fails for some reason.
+ * These exceptions are thrown whenever a [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction]
+ * or an action making up a [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction] fails for some reason.
  *
  * @author Ralph Gasser
  * @version 1.0
  */
 open class TransactionException(message: String) : DatabaseException(message) {
-    /** [Transaction] could not be created because enclosing DBO was closed.
+    /** [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction]
+     * could not be created because enclosing DBO was closed.
      *
      * @param tid The ID of the [Tx] in which this error occurred.
      */
     class TransactionDBOClosedException(tid: UUID): TransactionException("The enclosing DBO has been closed. Transaction $tid could not be created!")
 
     /**
-     * [Transaction] cannot be used anymore, because it is in error.
+     * [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction]
+     * cannot be used anymore, because it is in error.
      *
      * @param tid The ID of the [Tx] in which this error occurred.
      */
     class TransactionClosedException(tid: UUID): TransactionException("Transaction $tid has been closed and cannot be used anymore.")
 
     /**
-     * [Transaction]  cannot be used anymore, because it was closed already.
+     * [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction]
+     * cannot be used anymore, because it was closed already.
      *
      * @param tid The ID of the [Tx] in which this error occurred.
      */
     class TransactionInErrorException(tid: UUID): TransactionException("Transaction $tid is in error and cannot be used, until it is rolled back.")
 
     /**
-     * Write could not be executed, because [Transaction] is read-only.
+     * Write could not be executed, because [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction]
+     * is read-only.
      *
-     * @param tid The ID of the [Transaction] in which this error occurred.
+     * @param tid The ID of the [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction] in which this error occurred.
      */
     class TransactionReadOnlyException(tid: UUID): TransactionException("Transaction $tid is read-only and cannot be used to alter data.")
 
     /**
-     * Write could not be executed, because [Transaction] was unable to acquire the necessary locks (usually on DBOs).
+     * Write could not be executed, because [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction]
+     * was unable to acquire the necessary locks (usually on DBOs).
      *
-     * @param tid The ID of the [Transaction] in which this error occurred.
+     * @param tid The ID of the [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction] in which this error occurred.
      */
     class TransactionWriteLockException(tid: UUID): TransactionException("Transaction $tid was unable to obtain the necessary locks.")
 
     /**
      * Write could not be executed because it failed a validation step. This is usually caused by a user error, providing wrong data.
      *
-     * @param tid The ID of the [Transaction] in which this error occurred.
+     * @param tid The ID of the [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction] in which this error occurred.
      * @param message Description of the validation error.
      */
     class TransactionValidationException(tid: UUID, message: String): TransactionException("Transaction $tid reported validation error: $message")
@@ -58,7 +64,7 @@ open class TransactionException(message: String) : DatabaseException(message) {
      * Read/write could not be executed because it caused an error in the underlying data store. This is usually a critical condition and
      * can be caused by either system failure, external manipulation or serious bugs.
      *
-     * @param tid The ID of the [Transaction] in which this error occurred.
+     * @param tid The ID of the [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction] in which this error occurred.
      * @param message Description of the storage error.
      */
     class TransactionStorageException(tid: UUID, message: String): TransactionException("Transaction $tid reported storage error: $message")
@@ -66,7 +72,7 @@ open class TransactionException(message: String) : DatabaseException(message) {
     /**
      * Read/write could not be executed because some of the tuple IDs was invalid
      *
-     * @param tid The ID of the [Transaction] in which this error occurred.
+     * @param tid The ID of the [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction] in which this error occurred.
      * @param tupleId The tupleId that was wrong.
      */
     class InvalidTupleId(tid: UUID, tupleId: Long): DBException("Transaction $tid reported an error: The provided tuple ID $tupleId is out of bounds and therefore invalid.")
@@ -74,9 +80,9 @@ open class TransactionException(message: String) : DatabaseException(message) {
     /**
      * Read/write could not be executed because some of the colums don't exist.
      *
-     * @param tid The ID of the [Transaction] in which this error occurred.
-     * @param column The definition of the [Column] that is missing.
-     * @param entity The name of the [Entity] in which the column is missing.
+     * @param tid The ID of the [Transaction][ch.unibas.dmi.dbis.cottontail.database.general.Transaction] in which this error occurred.
+     * @param column The definition of the [Column][ch.unibas.dmi.dbis.cottontail.database.column.Column] that is missing.
+     * @param entity The name of the [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity] in which the column is missing.
      */
     class ColumnUnknownException(tid: UUID, column: ColumnDef<*>, entity: String): TransactionException("Transaction $tid could not be executed, because column '$entity.${column.name}' (type=${column.type.name}, size=${column.size}) does not either not exist or has a different type.")
 }

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/exceptions/ValidationException.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/exceptions/ValidationException.kt
@@ -10,7 +10,8 @@ package ch.unibas.dmi.dbis.cottontail.model.exceptions
 open class ValidationException(message: String) : DatabaseException(message) {
 
     /**
-     * Thrown by [Index] structures whenever their rebuild fails because of data constraints.
+     * Thrown by [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]
+     * structures whenever their rebuild fails because of data constraints.
      *
      * @param index The FQN of the index that was affected.
      * @param message A message describing the problem.

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/recordset/Recordset.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/recordset/Recordset.kt
@@ -18,10 +18,10 @@ import java.util.concurrent.atomic.AtomicLong
  * A record set as returned and processed by Cottontail DB. [Recordset]s are tables. Their columns are defined by the [ColumnDef]'s
  * it contains ([Recordset.columns] and it contains an arbitrary number of [Record] entries as rows.
  *
- * [Recordset]s are the unit of data retrieval and processing in Cottontail DB. Whenever information is accessed through an [Entity],
+ * [Recordset]s are the unit of data retrieval and processing in Cottontail DB. Whenever information is accessed through an [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity],
  * a [Recordset] is being generated. Furthermore, the entire query execution pipeline processes and produces [Recordset]s.
  *
- * @see Entity
+ * @see ch.unibas.dmi.dbis.cottontail.database.entity.Entity
  * @see QueryExecutionTask
  *
  * @author Ralph Gasser
@@ -46,7 +46,6 @@ class Recordset(val columns: Array<ColumnDef<*>>) : Scanable, Filterable {
     /**
      * Creates a new [Record] and appends it to this [Recordset]. This is a potentially unsafe operation.
      *
-     * @param tupleId The tupleId of the new [Record].
      * @param values The values to add to this [Recordset].
      */
     @Synchronized
@@ -90,7 +89,7 @@ class Recordset(val columns: Array<ColumnDef<*>>) : Scanable, Filterable {
     /**
      * Appends a [Record] (without a tupleId) to this [Recordset].
      *
-     * @param values The record to add to this [Recordset].
+     * @param record The record to add to this [Recordset].
      */
     @Synchronized
     fun addRow(record: Record) {
@@ -106,7 +105,7 @@ class Recordset(val columns: Array<ColumnDef<*>>) : Scanable, Filterable {
      * Creates a new [Record] given the provided tupleId and values and appends it to this [Recordset].
      *
      * @param tupleId The tupleId of the new [Record].
-     * @param values The values to add to this [Recordset].
+     * @param record The values to add to this [Recordset].
      */
     @Synchronized
     fun addRow(tupleId: Long, record: Record) {
@@ -123,7 +122,7 @@ class Recordset(val columns: Array<ColumnDef<*>>) : Scanable, Filterable {
      *
      * @param tupleId The tupleId of the new [Record].
      * @param predicate The [BooleanPredicate] to match the [Record] against
-     * @param values The values to add to this [Recordset].
+     * @param record The values to add to this [Recordset].
      * @return True if [Record] was added, false otherwise.
      */
     @Synchronized
@@ -401,7 +400,7 @@ class Recordset(val columns: Array<ColumnDef<*>>) : Scanable, Filterable {
      */
     inner class RecordsetRecord(override val tupleId: Long, init: Array<Value<*>?>? = null) : Record {
 
-        /** Array of [ColumnDef]s that describes the [Columns] of this [Record]. */
+        /** Array of [ColumnDef]s that describes the [Column][ch.unibas.dmi.dbis.cottontail.database.column.Column] of this [Record]. */
         override val columns: Array<out ColumnDef<*>>
             get() = this@Recordset.columns
 

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/recordset/StandaloneRecord.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/model/recordset/StandaloneRecord.kt
@@ -16,7 +16,7 @@ import ch.unibas.dmi.dbis.cottontail.model.values.Value
  */
 class StandaloneRecord(override val tupleId: Long = Long.MIN_VALUE, override val columns: Array<ColumnDef<*>>, init: Array<Value<*>?>? = null) : Record {
 
-    /** Array of column values (one entry per column). Initializes with null or the default value for the [ColumnType]. */
+    /** Array of column values (one entry per column). Initializes with null or the default value for the [ColumnType][ch.unibas.dmi.dbis.cottontail.database.column.ColumnType]. */
     override val values: Array<Value<*>?> = Array(columns.size) {
         if (this.columns[it].nullable) {
             null

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/server/grpc/services/CottonDDLService.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/server/grpc/services/CottonDDLService.kt
@@ -29,7 +29,7 @@ class CottonDDLService (val catalogue: Catalogue): CottonDDLGrpc.CottonDDLImplBa
         private val LOGGER = LoggerFactory.getLogger(CottonDDLService::class.java)
     }
     /**
-     * gRPC endpoint for creating a new [Schema]
+     * gRPC endpoint for creating a new [Schema][ch.unibas.dmi.dbis.cottontail.database.schema.Schema]
      */
     override fun createSchema(request: CottontailGrpc.Schema, responseObserver: StreamObserver<CottontailGrpc.SuccessStatus>) = try {
         LOGGER.trace("Creating schema {}", request.name)
@@ -50,7 +50,7 @@ class CottonDDLService (val catalogue: Catalogue): CottonDDLGrpc.CottonDDLImplBa
     }
 
     /**
-     * gRPC endpoint for dropping a [Schema]
+     * gRPC endpoint for dropping a [Schema][ch.unibas.dmi.dbis.cottontail.database.schema.Schema]
      */
     override fun dropSchema(request: CottontailGrpc.Schema, responseObserver: StreamObserver<CottontailGrpc.SuccessStatus>) = try {
         LOGGER.trace("Dropping schema {}", request.name)
@@ -71,7 +71,7 @@ class CottonDDLService (val catalogue: Catalogue): CottonDDLGrpc.CottonDDLImplBa
     }
 
     /**
-     * gRPC endpoint listing the available [Schema]s.
+     * gRPC endpoint listing the available [Schema][ch.unibas.dmi.dbis.cottontail.database.schema.Schema]s.
      */
     override fun listSchemas(request: CottontailGrpc.Empty, responseObserver: StreamObserver<CottontailGrpc.Schema>) = try {
         this.catalogue.schemas.forEach {
@@ -87,7 +87,7 @@ class CottonDDLService (val catalogue: Catalogue): CottonDDLGrpc.CottonDDLImplBa
 
     /**
      *
-     * gRPC endpoint for creating a new [Entity]
+     * gRPC endpoint for creating a new [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity]
      */
     override fun createEntity(request: CottontailGrpc.CreateEntityMessage, responseObserver: StreamObserver<CottontailGrpc.SuccessStatus>) = try {
         LOGGER.trace("Creating entity {}", request.entity.name)
@@ -115,7 +115,7 @@ class CottonDDLService (val catalogue: Catalogue): CottonDDLGrpc.CottonDDLImplBa
     }
 
     /**
-     * gRPC endpoint for dropping a particular [Schema]
+     * gRPC endpoint for dropping a particular [Schema][ch.unibas.dmi.dbis.cottontail.database.schema.Schema]
      */
     override fun dropEntity(request: CottontailGrpc.Entity, responseObserver: StreamObserver<CottontailGrpc.SuccessStatus>) = try {
         if (!(request.name as Name).isValid(NameType.SIMPLE)) {
@@ -137,7 +137,8 @@ class CottonDDLService (val catalogue: Catalogue): CottonDDLGrpc.CottonDDLImplBa
     }
 
     /**
-     * gRPC endpoint listing the available [Entity]s for the provided [Schema].
+     * gRPC endpoint listing the available [Entity][ch.unibas.dmi.dbis.cottontail.database.entity.Entity]s
+     * for the provided [Schema][ch.unibas.dmi.dbis.cottontail.database.schema.Schema].
      */
     override fun listEntities(request: CottontailGrpc.Schema, responseObserver: StreamObserver<CottontailGrpc.Entity>) = try {
         if (!(request.name as Name).isValid(NameType.SIMPLE)) {
@@ -159,7 +160,7 @@ class CottonDDLService (val catalogue: Catalogue): CottonDDLGrpc.CottonDDLImplBa
     }
 
     /**
-     * gRPC endpoint for creating a particular [Index]
+     * gRPC endpoint for creating a particular [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]
      */
     override fun createIndex(request: CottontailGrpc.CreateIndexMessage, responseObserver: StreamObserver<CottontailGrpc.SuccessStatus>) = try {
         val entity = this.catalogue.schemaForName(request.index.entity.schema.name).entityForName(request.index.entity.name)
@@ -192,7 +193,7 @@ class CottonDDLService (val catalogue: Catalogue): CottonDDLGrpc.CottonDDLImplBa
     }
 
     /**
-     * gRPC endpoint for dropping a particular [Index]
+     * gRPC endpoint for dropping a particular [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]
      */
     override fun dropIndex(request: CottontailGrpc.DropIndexMessage, responseObserver: StreamObserver<CottontailGrpc.SuccessStatus>) = try {
         if (!(request.index.name as Name).isValid(NameType.SIMPLE)) {
@@ -218,7 +219,7 @@ class CottonDDLService (val catalogue: Catalogue): CottonDDLGrpc.CottonDDLImplBa
     }
 
     /**
-     * gRPC endpoint for rebuilding a particular [Index]
+     * gRPC endpoint for rebuilding a particular [Index][ch.unibas.dmi.dbis.cottontail.database.index.Index]
      */
     override fun rebuildIndex(request: CottontailGrpc.RebuildIndexMessage, responseObserver: StreamObserver<CottontailGrpc.SuccessStatus>) = try {
         if (!(request.index.name as Name).isValid(NameType.SIMPLE)) {

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/server/grpc/services/CottonDMLService.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/server/grpc/services/CottonDMLService.kt
@@ -82,7 +82,7 @@ class CottonDMLService (val catalogue: Catalogue): CottonDMLGrpc.CottonDMLImplBa
      */
     override fun insertStream(responseObserver: StreamObserver<CottontailGrpc.InsertStatus>): StreamObserver<CottontailGrpc.InsertMessage> = object:StreamObserver<CottontailGrpc.InsertMessage>{
 
-        /** List of all the [Tx] associated with this call. */
+        /** List of all the [Entity.Tx] associated with this call. */
         private val transactions = ConcurrentHashMap<String, Entity.Tx>()
 
         /** Flag indicating that call was closed. */

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/storage/store/FileChannelStore.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/storage/store/FileChannelStore.kt
@@ -198,7 +198,7 @@ class FileChannelStore(val path: Path, val readOnly: Boolean, val lockTimeout: L
 
     /**
      * Generates and returns a [SeekableByteChannel] for this [MappedFileChannelStore]. The [SeekableByteChannel] can be used
-     * to efficiently transfer data between other [ByteChannel]s
+     * to efficiently transfer data between other [ByteChannel][java.nio.channels.ByteChannel]s
      *
      * @author Ralph Gasser
      * @version 1.0

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/storage/store/PersistentStore.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/storage/store/PersistentStore.kt
@@ -42,7 +42,7 @@ abstract class PersistentStore : Store {
 
     /**
      * Generates and returns a [SeekableByteChannel] for this [PersistentStore]. The [SeekableByteChannel] can be used
-     * to efficiently transfer data between other [ByteChannel]s.
+     * to efficiently transfer data between other [ByteChannel][java.nio.channels.ByteChannel]s.
      *
      * @author Ralph Gasser
      * @version 1.0

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/storage/store/Store.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/storage/store/Store.kt
@@ -178,7 +178,7 @@ interface Store : Closeable {
      * Writes a [ByteArray] value to this [Store]
      *
      * @param offset The offset into the [Store] in bytes.
-     * @param value The values to write.
+     * @param src The values to write.
      */
     fun putData(offset: Long, src: ByteArray) = putData(offset, src, 0, src.size)
 

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/utilities/name/Name.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/utilities/name/Name.kt
@@ -65,7 +65,7 @@ fun Name.type(): NameType = when {
 /**
  * Checks if this [Name] is a prefix of the provided [Name].
  *
- * @param other The [Name] to check.
+ * @param that The [Name] to check.
  */
 fun Name.isPrefixOf(that: Name): Boolean {
     val o = that.split(COTTONTAIL_NAME_COMPONENT_SEPARATOR)

--- a/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/utilities/name/NameUtilities.kt
+++ b/src/main/kotlin/ch/unibas/dmi/dbis/cottontail/utilities/name/NameUtilities.kt
@@ -4,7 +4,7 @@ object NameUtilities {
     /**
      * Finds the longest, common prefix the [Name]s in the given collection share.
      *
-     * @param strings Collection of [Name]s
+     * @param names Collection of [Name]s
      * @return Longest, common prefix.
      */
     public fun findLongestPrefix(names: Collection<Name>) : Name {

--- a/src/main/kotlin/org/mapdb/CottontailDBVolume.kt
+++ b/src/main/kotlin/org/mapdb/CottontailDBVolume.kt
@@ -23,7 +23,7 @@ import kotlin.math.max
 
 
 /**
- * This is a re-implementation / copy of Map DB's [ByteBufferVol] class with minor modifications.
+ * This is a re-implementation / copy of Map DB's [ByteBufferVol][org.mapdb.volume.ByteBufferVol] class with minor modifications.
  *
  * @version 1.0
  * @author Ralph Gasser


### PR DESCRIPTION
Fix a lot of the kdoc comments where references were not properly written.

There are some unresolved references left, most of which I was not sure what they should refer to specifically, due to multiple possible targets.

I mostly did this because I dislike not being able to click on references in Intellij, makes my life difficult.